### PR TITLE
Add FoodItem page

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/ecohive/app/data/FoodItem.kt
+++ b/composeApp/src/commonMain/kotlin/com/ecohive/app/data/FoodItem.kt
@@ -1,6 +1,7 @@
 package com.ecohive.app.data
 
 data class FoodItem(
+    val id: String,
     val imageUrl: String,
     val name: String,
     val price: Double,
@@ -16,6 +17,7 @@ enum class SpiceLevel {
 val mockFoodItems = listOf(
     // Most Popular
     FoodItem(
+        id = "1",
         imageUrl = "",
         name = "Margherita Pizza",
         price = 12.99,
@@ -23,6 +25,7 @@ val mockFoodItems = listOf(
         spiceLevel = SpiceLevel.NONE
     ),
     FoodItem(
+        id = "2",
         imageUrl = "",
         name = "Cheeseburger",
         price = 9.99,
@@ -32,6 +35,7 @@ val mockFoodItems = listOf(
 
     // Pasta
     FoodItem(
+        id = "3",
         imageUrl = "",
         name = "Carbonara",
         price = 13.49,
@@ -39,6 +43,7 @@ val mockFoodItems = listOf(
         spiceLevel = SpiceLevel.NONE
     ),
     FoodItem(
+        id = "4",
         imageUrl = "",
         name = "Spaghetti Bolognese",
         price = 11.99,
@@ -48,6 +53,7 @@ val mockFoodItems = listOf(
 
     // Pizza
     FoodItem(
+        id = "5",
         imageUrl = "",
         name = "Pepperoni Pizza",
         price = 14.99,
@@ -55,6 +61,7 @@ val mockFoodItems = listOf(
         spiceLevel = SpiceLevel.MEDIUM
     ),
     FoodItem(
+        id = "6",
         imageUrl = "",
         name = "BBQ Chicken Pizza",
         price = 15.49,
@@ -64,6 +71,7 @@ val mockFoodItems = listOf(
 
     // Salads
     FoodItem(
+        id = "7",
         imageUrl = "",
         name = "Caesar Salad",
         price = 8.99,
@@ -71,6 +79,7 @@ val mockFoodItems = listOf(
         spiceLevel = SpiceLevel.NONE
     ),
     FoodItem(
+        id = "8",
         imageUrl = "",
         name = "Greek Salad",
         price = 9.49,
@@ -80,6 +89,7 @@ val mockFoodItems = listOf(
 
     // Spicy Options
     FoodItem(
+        id = "9",
         imageUrl = "",
         name = "Spicy Chicken Wings",
         price = 10.99,
@@ -87,6 +97,7 @@ val mockFoodItems = listOf(
         spiceLevel = SpiceLevel.EXTRA_HOT
     ),
     FoodItem(
+        id = "10",
         imageUrl = "",
         name = "Spicy Beef Taco",
         price = 7.99,

--- a/composeApp/src/commonMain/kotlin/com/ecohive/app/data/RestaurantDataClass.kt
+++ b/composeApp/src/commonMain/kotlin/com/ecohive/app/data/RestaurantDataClass.kt
@@ -10,6 +10,7 @@ data class Restaurant(
     val banner: Int, // Image resource ID
     val rating: Double,
     val deliveryCharge: Double,
+    val discountPercentage: Int,
     val eta: String,
     val menu: Map<String, List<FoodItem>> // Categories like "Most Popular", "Pizza", etc.
 )
@@ -25,11 +26,13 @@ val mockRestaurant1 = Restaurant(
     banner = 1,
     rating = 4.5,
     deliveryCharge = 2.99,
+    discountPercentage = 50,
     eta = "30-40 min",
     menu = mapOf(
         // Most Popular Items
         "Most Popular" to listOf(
             FoodItem(
+                id = "1",
                 imageUrl = "https://images.unsplash.com/photo-1564936281291-294551497d81?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8NHx8cGl6emElMjBtYXJnaGVyaXRhfGVufDB8fDB8fHww",
                 name = "Margherita Pizza",
                 price = 12.99,
@@ -37,6 +40,7 @@ val mockRestaurant1 = Restaurant(
                 spiceLevel = SpiceLevel.NONE
             ),
             FoodItem(
+                id = "2",
                 imageUrl = "https://images.unsplash.com/photo-1572802419224-296b0aeee0d9?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8Mnx8Y2hlZXNlYnVyZ2VyfGVufDB8fDB8fHww",
                 name = "Cheeseburger",
                 price = 9.99,
@@ -48,6 +52,7 @@ val mockRestaurant1 = Restaurant(
         // Pizza
         "Pizza" to listOf(
             FoodItem(
+                id = "3",
                 imageUrl = "https://images.unsplash.com/photo-1628840042765-356cda07504e?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8Mnx8cGVwcGVyb25pJTIwcGl6emF8ZW58MHx8MHx8fDA%3D",
                 name = "Pepperoni Pizza",
                 price = 14.99,
@@ -55,6 +60,7 @@ val mockRestaurant1 = Restaurant(
                 spiceLevel = SpiceLevel.MEDIUM
             ),
             FoodItem(
+                id = "4",
                 imageUrl = "https://images.unsplash.com/photo-1734769484424-36b99dd84818?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8M3x8YmJxJTIwY2hpY2tlbiUyMHBpenphfGVufDB8fDB8fHww",
                 name = "BBQ Chicken Pizza",
                 price = 15.49,
@@ -66,6 +72,7 @@ val mockRestaurant1 = Restaurant(
         // Pasta
         "Pasta" to listOf(
             FoodItem(
+                id = "5",
                 imageUrl = "https://images.unsplash.com/photo-1588013273468-315fd88ea34c?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8Nnx8Y2FyYm9uYXJhfGVufDB8fDB8fHww",
                 name = "Carbonara",
                 price = 13.49,
@@ -73,6 +80,7 @@ val mockRestaurant1 = Restaurant(
                 spiceLevel = SpiceLevel.NONE
             ),
             FoodItem(
+                id = "6",
                 imageUrl = "https://plus.unsplash.com/premium_photo-1674511582428-58ce834ce172?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8OXx8c3BhZ2hldHRpJTIwYm9sb2duZXplfGVufDB8fDB8fHww",
                 name = "Spaghetti Bolognese",
                 price = 11.99,
@@ -84,6 +92,7 @@ val mockRestaurant1 = Restaurant(
         // Salads
         "Salads" to listOf(
             FoodItem(
+                id = "7",
                 imageUrl = "https://images.unsplash.com/photo-1512852939750-1305098529bf?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8Mnx8Y2Flc2FyJTIwc2FsYWR8ZW58MHx8MHx8fDA%3D",
                 name = "Caesar Salad",
                 price = 8.99,
@@ -91,6 +100,7 @@ val mockRestaurant1 = Restaurant(
                 spiceLevel = SpiceLevel.NONE
             ),
             FoodItem(
+                id = "8",
                 imageUrl = "https://images.unsplash.com/photo-1549745708-fa4a8423a0b4?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MTJ8fGdyZWVrJTIwc2FsYWR8ZW58MHx8MHx8fDA%3D",
                 name = "Greek Salad",
                 price = 9.49,
@@ -108,11 +118,13 @@ val mockRestaurant2 = Restaurant(
     banner = 2,
     rating = 4.7,
     deliveryCharge = 1.99,
+    discountPercentage = 20,
     eta = "25-35 min",
     menu = mapOf(
         // Breads
         "Breads" to listOf(
             FoodItem(
+                id = "9",
                 imageUrl = "https://plus.unsplash.com/premium_photo-1661673920262-1dd7abc2faa7?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MTN8fHNvdXJkb3VnaCUyMGJyZWFkfGVufDB8fDB8fHww",
                 name = "Sourdough Bread",
                 price = 5.99,
@@ -120,6 +132,7 @@ val mockRestaurant2 = Restaurant(
                 spiceLevel = SpiceLevel.NONE
             ),
             FoodItem(
+                id = "10",
                 imageUrl = "https://images.unsplash.com/photo-1549931319-a545dcf3bc73?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8NHx8d2hvbGUlMjB3aGVhdCUyMGJyZWFkfGVufDB8fDB8fHww",
                 name = "Whole Wheat Bread",
                 price = 4.99,
@@ -131,6 +144,7 @@ val mockRestaurant2 = Restaurant(
         // Pastries
         "Pastries" to listOf(
             FoodItem(
+                id = "11",
                 imageUrl = "https://images.unsplash.com/photo-1599940778173-e276d4acb2bb?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8NHx8Y3JvaXNzYW50fGVufDB8fDB8fHww",
                 name = "Croissant",
                 price = 3.49,
@@ -138,6 +152,7 @@ val mockRestaurant2 = Restaurant(
                 spiceLevel = SpiceLevel.NONE
             ),
             FoodItem(
+                id = "12",
                 imageUrl = "https://images.unsplash.com/photo-1613994747257-20e333b5f76e?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MTh8fGNob2NvbGF0ZSUyMGRhbmlzaHxlbnwwfHwwfHx8MA%3D%3D",
                 name = "Chocolate Danish",
                 price = 4.29,
@@ -149,6 +164,7 @@ val mockRestaurant2 = Restaurant(
         // Cakes
         "Cakes" to listOf(
             FoodItem(
+                id = "13",
                 imageUrl = "https://images.unsplash.com/photo-1586788680434-30d324b2d46f?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8Mnx8cmVkJTIwdmVsdmV0JTIwY2FrZXxlbnwwfHwwfHx8MA%3D%3D",
                 name = "Red Velvet Cake",
                 price = 15.99,
@@ -156,6 +172,7 @@ val mockRestaurant2 = Restaurant(
                 spiceLevel = SpiceLevel.NONE
             ),
             FoodItem(
+                id = "14",
                 imageUrl = "https://images.unsplash.com/photo-1631206753348-db44968fd440?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MTJ8fHRpcmFtaXN1fGVufDB8fDB8fHww",
                 name = "Tiramisu",
                 price = 14.49,
@@ -173,11 +190,13 @@ val mockRestaurant3 = Restaurant(
     banner = 3,
     rating = 4.8,
     deliveryCharge = 3.49,
+    discountPercentage = 30,
     eta = "40-50 min",
     menu = mapOf(
         // Starters
         "Starters" to listOf(
             FoodItem(
+                id = "15",
                 imageUrl = "https://images.unsplash.com/photo-1601050690597-df0568f70950?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8Mnx8c2Ftb3NhfGVufDB8fDB8fHww",
                 name = "Samosa",
                 price = 6.99,
@@ -185,6 +204,7 @@ val mockRestaurant3 = Restaurant(
                 spiceLevel = SpiceLevel.MEDIUM
             ),
             FoodItem(
+                id = "16",
                 imageUrl = "https://images.unsplash.com/photo-1567188040759-fb8a883dc6d8?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8Mnx8cGFuZWVyJTIwdGlra2F8ZW58MHx8MHx8fDA%3D",
                 name = "Paneer Tikka",
                 price = 8.99,
@@ -196,6 +216,7 @@ val mockRestaurant3 = Restaurant(
         // Main Course
         "Main Course" to listOf(
             FoodItem(
+                id = "17",
                 imageUrl = "https://images.unsplash.com/photo-1610057099443-fde8c4d50f91?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8Nnx8YnV0dGVyJTIwY2hpY2tlbnxlbnwwfHwwfHx8MA%3D%3D",
                 name = "Butter Chicken",
                 price = 16.99,
@@ -203,6 +224,7 @@ val mockRestaurant3 = Restaurant(
                 spiceLevel = SpiceLevel.MEDIUM
             ),
             FoodItem(
+                id = "18",
                 imageUrl = "https://images.unsplash.com/photo-1589647363585-f4a7d3877b10?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8Mnx8cGFsYWslMjBwYW5lZXJ8ZW58MHx8MHx8fDA%3D",
                 name = "Palak Paneer",
                 price = 14.49,

--- a/composeApp/src/commonMain/kotlin/com/ecohive/app/ui/components/FoodCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/ecohive/app/ui/components/FoodCard.kt
@@ -53,6 +53,7 @@ fun SimpleFoodCard(
 fun PreviewSimpleFoodCard() {
     SimpleFoodCard(
         foodItem = FoodItem(
+            id = "1",
             imageUrl = "", // No image yet
             name = "Margherita Pizza",
             price = 12.99,

--- a/composeApp/src/commonMain/kotlin/com/ecohive/app/ui/pages/FoodItemPage.kt
+++ b/composeApp/src/commonMain/kotlin/com/ecohive/app/ui/pages/FoodItemPage.kt
@@ -1,0 +1,152 @@
+package com.ecohive.app.ui.pages
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil3.compose.AsyncImage
+import com.ecohive.app.data.FoodItem
+import com.ecohive.app.data.SpiceLevel
+import com.example.compose.errorLight
+import com.example.compose.tertiaryContainerDarkMediumContrast
+import com.example.compose.tertiaryContainerLight
+import com.example.compose.tertiaryLight
+import kotlin.math.round
+
+@Composable
+fun FoodItemPage(foodItemId: String, discount: Int, modifier: Modifier = Modifier, onClose: () -> Unit = {}) {
+    // Mock data for now -- this will need to be either a lookup/have the foodItem given as parameter
+    // from the restaurant
+    val foodItem = FoodItem(
+        id = "1",
+        imageUrl = "https://www.grandecheese.com/wp-content/uploads/2021/01/Margherita-Pizza-deck-oven.jpg",
+        name = "Margherita Pizza",
+        price = 12.99,
+        ingredients = listOf("Tomato Sauce", "Mozzarella", "Basil"),
+        spiceLevel = SpiceLevel.NONE
+    )
+
+    Column(modifier = modifier.fillMaxSize()) {
+        // Image Banner Component
+        Box(modifier = modifier.height(250.dp)) {
+            AsyncImage(
+                model = foodItem.imageUrl,
+                contentDescription = foodItem.name,
+                contentScale = ContentScale.Crop,
+                modifier = modifier.fillMaxWidth().height(200.dp)
+            )
+            IconButton(
+                onClick = onClose,
+                modifier = modifier
+                    .align(Alignment.TopStart)
+                    .padding(12.dp)
+                    .background(Color.Black.copy(alpha = 0.4f), shape = RoundedCornerShape(50))
+            ) {
+                Icon(imageVector = Icons.Default.Close, contentDescription = "Close", tint = Color.White)
+            }
+        }
+
+        // Food Item Name and discount
+        Column(modifier = modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = foodItem.name,
+                    style = MaterialTheme.typography.headlineSmall,
+                    modifier = modifier.weight(1f)
+                )
+                Box(
+                    modifier = modifier
+                        .background(MaterialTheme.colorScheme.error, shape = RoundedCornerShape(4.dp))
+                        .padding(horizontal = 6.dp, vertical = 2.dp)
+                ) {
+                    Text("${discount}%", color = Color.White, fontSize = 12.sp)
+                }
+            }
+
+            Spacer(modifier.height(4.dp))
+
+            // Food Item Price (with discount applied)
+            Row {
+                Text(
+                    text = "RON ${foodItem.price}",
+                    style = MaterialTheme.typography.bodyMedium.copy(
+                        textDecoration = TextDecoration.LineThrough,
+                        color = Color.Gray
+                    )
+                )
+                Spacer(modifier.width(8.dp))
+                val discountedPrice = (foodItem.price * (100 - discount)) / 100.0
+                val roundedPrice = (discountedPrice * 100).toInt() / 100.0
+                Text(
+                    text = "RON ${roundedPrice}",
+                    style = MaterialTheme.typography.bodyLarge.copy(color = MaterialTheme.colorScheme.error)
+                )
+            }
+
+            Spacer(modifier.height(12.dp))
+
+            // Food Item Ingredients
+            Text(
+                text = "Ingredients:",
+                style = MaterialTheme.typography.bodyMedium.copy(fontWeight = androidx.compose.ui.text.font.FontWeight.Bold)
+            )
+
+            Text(
+                text = foodItem.ingredients.joinToString(),
+                style = MaterialTheme.typography.bodyMedium
+            )
+
+            Spacer(modifier.height(24.dp))
+
+            // Select Quantity and Add Button
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                // Quantity selector
+                Box(
+                    modifier = modifier
+                        .border(
+                            width = 1.dp,
+                            color = MaterialTheme.colorScheme.tertiaryContainer, // or Color.Gray, Color(0xFF...)
+                            shape = RoundedCornerShape(8.dp) // optional, makes corners rounded
+                        )
+                        .background(Color(0xFFEFEFEF), shape = RoundedCornerShape(8.dp))
+                        .padding(horizontal = 12.dp, vertical = 8.dp)
+                ) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text("-", modifier.padding(end = 8.dp), color = MaterialTheme.colorScheme.onBackground,)
+                        Text("1", modifier.padding(horizontal = 4.dp), color = MaterialTheme.colorScheme.onBackground,)
+                        Text("+", modifier.padding(start = 8.dp), color = MaterialTheme.colorScheme.onBackground,)
+                    }
+                }
+
+                Spacer(modifier.width(16.dp))
+
+                // Add Button
+                Button(
+                    onClick = { /* Add to cart */ },
+                    colors = ButtonDefaults.buttonColors().copy(
+                        containerColor = MaterialTheme.colorScheme.tertiary,
+                        contentColor = Color.White
+                    ),
+                    shape = RoundedCornerShape(8.dp),
+                    modifier = modifier.height(48.dp)
+                ) {
+                    Text("ADD", color = Color.White)
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/ecohive/app/ui/screens/RestaurantsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/ecohive/app/ui/screens/RestaurantsScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import com.ecohive.app.ui.pages.FoodItemPage
 
 @Composable
 fun RestaurantsScreen(
@@ -27,6 +28,7 @@ fun RestaurantsScreen(
 
         // NOTE: Just for testing a restaurant page, can be removed
         // RestaurantPage(restaurant = mockRestaurant1, modifier = Modifier.fillMaxWidth())
+//        FoodItemPage("1", 50)
     }
 }
 


### PR DESCRIPTION
Made minor changes to data classes:
- FoodItem: Add id
- Restaurant: Add discount

The food item page takes as a parameter the ID of the food item (this could be changed to be of type FoodItem or kept as ID if we're gonna have a centralised database/use the mock data provided in the data classes).

Final look:
![image](https://github.com/user-attachments/assets/9f04f38f-c72b-45ee-a6a6-18505a2b7dd0)

