### PR TITLE
Add account page and screen

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/ecohive/app/data/OrderItem.kt
+++ b/composeApp/src/commonMain/kotlin/com/ecohive/app/data/OrderItem.kt
@@ -1,0 +1,29 @@
+package com.ecohive.app.data
+
+data class OrderItem(
+    val restaurant: Restaurant,
+    val price: Double,
+    val date: String,
+    val time: String,
+)
+
+val mockOrderItem1 = OrderItem(
+    restaurant = mockRestaurant1,
+    price = 20.00,
+    date = "2025-01-01",
+    time = "14:00",
+)
+
+val mockOrderItem2 = OrderItem(
+    restaurant = mockRestaurant2,
+    price = 24.99,
+    date = "2025-02-14",
+    time = "12:33",
+)
+
+val mockOrderItem3 = OrderItem(
+    restaurant = mockRestaurant3,
+    price = 19.80,
+    date = "2025-03-25",
+    time = "18:45",
+)

--- a/composeApp/src/commonMain/kotlin/com/ecohive/app/data/PaymentItem.kt
+++ b/composeApp/src/commonMain/kotlin/com/ecohive/app/data/PaymentItem.kt
@@ -1,0 +1,11 @@
+package com.ecohive.app.data
+
+data class PaymentItem(
+    val paymentMethod: String,
+    val cardNumber: String,
+)
+
+val mockPaymentItem = PaymentItem(
+    paymentMethod = "Apple Pay",
+    cardNumber = "1234 5678 9012 3456",
+)

--- a/composeApp/src/commonMain/kotlin/com/ecohive/app/data/UserItem.kt
+++ b/composeApp/src/commonMain/kotlin/com/ecohive/app/data/UserItem.kt
@@ -1,0 +1,17 @@
+package com.ecohive.app.data
+
+data class UserItem(
+    val name: String,
+    val email: String,
+    val phone: String,
+    val payment: PaymentItem,
+    val orders: List<OrderItem>
+)
+
+val mockUserItem = UserItem(
+    name = "Jamila Cuisine",
+    email = "jamila_cuisine@gmail.com",
+    phone = "+078901234567",
+    payment = mockPaymentItem,
+    orders = listOf(mockOrderItem1, mockOrderItem2, mockOrderItem3)
+)

--- a/composeApp/src/commonMain/kotlin/com/ecohive/app/ui/components/OrderCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/ecohive/app/ui/components/OrderCard.kt
@@ -1,0 +1,35 @@
+package com.ecohive.app.ui.components
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.ecohive.app.data.OrderItem
+import coil3.compose.AsyncImage
+import androidx.compose.ui.layout.ContentScale
+
+@Composable
+fun OrderCard(orderItem: OrderItem, modifier: Modifier = Modifier) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.padding(vertical = 8.dp)
+    ) {
+        AsyncImage(
+            model = orderItem.restaurant.banner,
+            contentDescription = orderItem.restaurant.name,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier.size(80.dp)
+        )
+        Spacer(modifier = Modifier.width(16.dp))
+        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text(orderItem.restaurant.name, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+            Text("${orderItem.price} RON", style = MaterialTheme.typography.bodyLarge, color = MaterialTheme.colorScheme.secondary)
+            Text("Delivered on ${orderItem.date} at ${orderItem.time}", style = MaterialTheme.typography.bodySmall, color = Color.Gray)
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/ecohive/app/ui/components/ProfileCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/ecohive/app/ui/components/ProfileCard.kt
@@ -1,0 +1,58 @@
+package com.ecohive.app.ui.components
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountBox
+import androidx.compose.material.icons.filled.Email
+import androidx.compose.material.icons.filled.Phone
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.ecohive.app.data.UserItem
+
+@Composable
+fun ProfileCard(user: UserItem, modifier: Modifier = Modifier) {
+    Column(
+        modifier = Modifier.padding(vertical = 8.dp)
+    ) {
+        // Name
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(vertical = 4.dp)
+        ) {
+            Icon(Icons.Filled.AccountBox, contentDescription = "Full Name", modifier = Modifier.size(24.dp), tint = Color.Gray)
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(user.name, style = MaterialTheme.typography.bodyLarge, color = MaterialTheme.colorScheme.onBackground)
+        }
+
+        // Phone Number
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(vertical = 4.dp)
+        ) {
+            Icon(Icons.Filled.Phone, contentDescription = "Phone Number", modifier = Modifier.size(24.dp), tint = Color.Gray)
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(user.phone, style = MaterialTheme.typography.bodyLarge, color = MaterialTheme.colorScheme.onBackground)
+        }
+
+        // Email
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(vertical = 4.dp)
+        ) {
+            Icon(Icons.Filled.Email, contentDescription = "Email", modifier = Modifier.size(24.dp), tint = Color.Gray)
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(user.email, style = MaterialTheme.typography.bodyLarge, color = MaterialTheme.colorScheme.onBackground)
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/ecohive/app/ui/navigation/NavHost.kt
+++ b/composeApp/src/commonMain/kotlin/com/ecohive/app/ui/navigation/NavHost.kt
@@ -41,6 +41,7 @@ import com.ecohive.app.data.Restaurant
 import com.ecohive.app.data.restaurantLocationList
 import com.ecohive.app.ui.pages.RestaurantPage
 import com.ecohive.app.ui.screens.LandingScreen
+import com.ecohive.app.ui.screens.AccountScreen
 import com.ecohive.app.ui.screens.RestaurantsScreen
 import kotlinx.serialization.Serializable
 
@@ -166,7 +167,7 @@ fun EcoHiveApp(
                 Text("Settings")
             }
             composable<Account> {
-                Text("account")
+                AccountScreen(onClick = { navHostController.navigate(Landing) })
             }
             composable<RestaurantDetails> { backStackEntry ->
                 val restaurantDetails: RestaurantDetails = backStackEntry.toRoute()

--- a/composeApp/src/commonMain/kotlin/com/ecohive/app/ui/pages/AccountPage.kt
+++ b/composeApp/src/commonMain/kotlin/com/ecohive/app/ui/pages/AccountPage.kt
@@ -1,0 +1,94 @@
+package com.ecohive.app.ui.pages
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.CreditCard
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.ecohive.app.data.OrderItem
+import com.ecohive.app.data.UserItem
+import com.ecohive.app.ui.components.OrderCard
+import com.ecohive.app.ui.components.ProfileCard
+
+@Composable
+fun AccountPage(user: UserItem, modifier: Modifier = Modifier) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        // Hello, Name
+        Text(
+            text = "Hello, ${user.name}",
+            style = MaterialTheme.typography.headlineLarge,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(bottom = 24.dp)
+        )
+
+        // Profile Section
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(
+                "Profile",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold
+            )
+            IconButton(onClick = { /* TODO: Handle Edit Profile */ }) {
+                Icon(Icons.Filled.Edit, contentDescription = "Edit Profile", tint = MaterialTheme.colorScheme.tertiary)
+            }
+        }
+        ProfileCard(user = user, modifier)
+        Divider(modifier = Modifier.padding(vertical = 16.dp))
+
+        // Payment Section
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(
+                "Payment",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold
+            )
+            IconButton(onClick = { /* TODO: Handle Edit Payment */ }) {
+                Icon(Icons.Filled.Edit, contentDescription = "Edit Payment", tint = MaterialTheme.colorScheme.tertiary)
+            }
+        }
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(vertical = 4.dp)
+        ) {
+            Icon(Icons.Filled.CreditCard, contentDescription = "Payment Method", modifier = Modifier.size(24.dp), tint = Color.Gray)
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(user.payment.paymentMethod, style = MaterialTheme.typography.bodyLarge)
+        }
+        Divider(modifier = Modifier.padding(vertical = 16.dp))
+
+        // Order History Section
+        Text(
+            "Order history",
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(bottom = 16.dp)
+        )
+        LazyColumn {
+            items(user.orders) { orderItem ->
+                OrderCard(orderItem = orderItem, modifier)
+                Divider() // Add a divider between each order
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/ecohive/app/ui/screens/AccountScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/ecohive/app/ui/screens/AccountScreen.kt
@@ -1,0 +1,21 @@
+package com.ecohive.app.ui.screens
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.ecohive.app.data.mockUserItem
+import com.ecohive.app.ui.pages.AccountPage
+
+@Composable
+fun AccountScreen(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = Modifier.fillMaxSize()
+    ) {
+        AccountPage(mockUserItem, modifier)
+    }
+}
+


### PR DESCRIPTION
Updates:
- Restaurant banner type changed to String and examples changed to URLs (let's not keep images statically in the app)
- Added OrderItem, UserItem and PaymentItem data types
- Added OrderCard and ProfileCard components
- Added Account page
- Added Account screen and updated navigation logic

!!! Requires image plugins commit from #24 

Order list is scrollable, edit buttons don't do anything yet.

I took some artistic liberties (profile and payment are not side-by-side like in the design):
![image](https://github.com/user-attachments/assets/842fbdd4-8b49-4a34-8dfb-b8a38347373e)
